### PR TITLE
docs: move MCP Server section to first in nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,6 +11,68 @@
   "navigation": {
     "versions": [
       {
+        "version": "MCP Server",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "mcp-server/quickstart",
+              "development-vs-production",
+              "technical-specs"
+            ]
+          },
+          {
+            "group": "Operations",
+            "pages": [
+              "mcp-server/operations/authentication",
+              "mcp-server/operations/creating-instances",
+              "mcp-server/operations/connecting-to-instances",
+              "mcp-server/operations/monitoring-instances",
+              "mcp-server/operations/file-transfers",
+              "mcp-server/operations/port-forwarding",
+              "mcp-server/operations/modifying-instances",
+              "mcp-server/operations/snapshots",
+              "mcp-server/operations/deleting-instances",
+              "mcp-server/operations/ssh"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "guides/running-jupyter-notebooks-on-thunder-compute",
+              "guides/using-instance-templates",
+              "guides/speeding-up-snapshots",
+              "guides/stopping-instances",
+              "guides/using-docker-on-thundercompute",
+              "guides/unsloth-studio",
+              "guides/unsloth-studio-finetune",
+              {
+                "group": "Models",
+                "root": "guides/models",
+                "expanded": false,
+                "pages": [
+                  "guides/models/qwen3-6-27b",
+                  "guides/gpt-oss-running-locally-on-thunder-compute",
+                  "guides/deepseek-r1-running-locally-on-thunder-compute"
+                ]
+              },
+              "guides/referral-program",
+              "guides/data-processing-addendum",
+              "guides/weights-and-biases",
+              "guides/mcp-server"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": ["troubleshooting", "billing", "restrictions"]
+          },
+          {
+            "group": "API Reference",
+            "openapi": "https://api.thundercompute.com:8443/openapi.json"
+          }
+        ]
+      },
+      {
         "version": "VS Code extension",
         "groups": [
           {
@@ -61,68 +123,6 @@
               "guides/weights-and-biases",
               "guides/mcp-server",
               "guides/openclaw-thunder-compute-beta"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": ["troubleshooting", "billing", "restrictions"]
-          },
-          {
-            "group": "API Reference",
-            "openapi": "https://api.thundercompute.com:8443/openapi.json"
-          }
-        ]
-      },
-      {
-        "version": "MCP Server",
-        "groups": [
-          {
-            "group": "Getting Started",
-            "pages": [
-              "mcp-server/quickstart",
-              "development-vs-production",
-              "technical-specs"
-            ]
-          },
-          {
-            "group": "Operations",
-            "pages": [
-              "mcp-server/operations/authentication",
-              "mcp-server/operations/creating-instances",
-              "mcp-server/operations/connecting-to-instances",
-              "mcp-server/operations/monitoring-instances",
-              "mcp-server/operations/file-transfers",
-              "mcp-server/operations/port-forwarding",
-              "mcp-server/operations/modifying-instances",
-              "mcp-server/operations/snapshots",
-              "mcp-server/operations/deleting-instances",
-              "mcp-server/operations/ssh"
-            ]
-          },
-          {
-            "group": "Guides",
-            "pages": [
-              "guides/running-jupyter-notebooks-on-thunder-compute",
-              "guides/using-instance-templates",
-              "guides/speeding-up-snapshots",
-              "guides/stopping-instances",
-              "guides/using-docker-on-thundercompute",
-              "guides/unsloth-studio",
-              "guides/unsloth-studio-finetune",
-              {
-                "group": "Models",
-                "root": "guides/models",
-                "expanded": false,
-                "pages": [
-                  "guides/models/qwen3-6-27b",
-                  "guides/gpt-oss-running-locally-on-thunder-compute",
-                  "guides/deepseek-r1-running-locally-on-thunder-compute"
-                ]
-              },
-              "guides/referral-program",
-              "guides/data-processing-addendum",
-              "guides/weights-and-biases",
-              "guides/mcp-server"
             ]
           },
           {


### PR DESCRIPTION
## What

Reorders the docs nav `versions` array so **MCP Server** is the first option: `[MCP Server, VS Code extension, CLI, Console]` (was `[VS Code extension, MCP Server, CLI, Console]`).

## Why

Part of THU-2669. The ticket asked to put the "agents" option first again; that section was since renamed to **MCP Server**, so this makes MCP Server the leading nav entry.

## Notes

- Pure block move in `docs.json` — identical line multiset vs HEAD (no content added or removed), valid JSON.
- Ephemeral-storage removal (the other half of THU-2669) was already landed on `main` separately, so it is intentionally not part of this PR.